### PR TITLE
Use rustls-mbedtls-provider for server and client in qdrant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +712,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease 0.2.17",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
@@ -703,8 +765,14 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bit-vec"
@@ -1068,6 +1136,15 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -1578,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "dataset"
 version = "0.0.0"
 dependencies = [
@@ -1594,6 +1677,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1654,6 +1751,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2964,7 +3072,7 @@ version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
  "bzip2-sys",
  "cc",
  "glob",
@@ -3402,6 +3510,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "mbedtls"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8730cf71e8d79ba70b3b7986af7af7629c0c4ee58b59e4a2e30d855cc31552e8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cc",
+ "cfg-if",
+ "chrono",
+ "mbedtls-platform-support",
+ "mbedtls-sys-auto",
+ "rs-libc",
+ "serde",
+ "serde_derive",
+ "yasna 0.2.2",
+]
+
+[[package]]
+name = "mbedtls-platform-support"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "chrono",
+ "mbedtls-sys-auto",
+]
+
+[[package]]
+name = "mbedtls-sys-auto"
+version = "2.28.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11bb8ccdfd2a163117d977677665a2008fbd9ab38c884b0b8a57828219868dc0"
+dependencies = [
+ "bindgen 0.65.1",
+ "cc",
+ "cfg-if",
+ "cmake",
+ "lazy_static",
+ "libc",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3766,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
@@ -3722,6 +3888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,6 +3997,12 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -4163,7 +4344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.6.3",
  "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
@@ -4440,6 +4621,10 @@ dependencies = [
  "reqwest 0.12.5",
  "rstack-self",
  "rustls 0.23.11",
+ "rustls-mbedcrypto-provider",
+ "rustls-mbedpki-provider",
+ "rustls-mbedtls-provider-utils",
+ "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "rusty-hook",
@@ -4972,6 +5157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rs-libc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683e8c8e8aac6ffa4b2287bac3c69575d5346accac4f218ae1e084303bb174ca"
+dependencies = [
+ "cc",
+ "zeroize",
+]
+
+[[package]]
 name = "rstack"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5071,6 +5266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,6 +5340,44 @@ dependencies = [
  "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-mbedcrypto-provider"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6841ca311a5a41f618eb7095aaa2d3ab8810a540c9e57ce6ce63b0e0431070bc"
+dependencies = [
+ "bit-vec 0.6.3",
+ "log",
+ "mbedtls",
+ "rustls 0.23.11",
+ "rustls-mbedtls-provider-utils",
+ "rustls-webpki 0.102.5",
+ "yasna 0.3.2",
+]
+
+[[package]]
+name = "rustls-mbedpki-provider"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4245e05baaa3493865cc15f80e6520c52423936b409a695f57c3f92d1aad71"
+dependencies = [
+ "chrono",
+ "mbedtls",
+ "rustls 0.23.11",
+ "rustls-mbedtls-provider-utils",
+ "x509-parser",
+]
+
+[[package]]
+name = "rustls-mbedtls-provider-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec33e15661de795beee762ce87767de05aa01c7ca69dbd8275ae84e9ecab81dc"
+dependencies = [
+ "mbedtls",
+ "rustls 0.23.11",
 ]
 
 [[package]]
@@ -5671,7 +5913,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "thiserror",
  "time",
@@ -5993,6 +6235,18 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+ "unicode-xid",
+]
 
 [[package]]
 name = "sys-info"
@@ -6646,6 +6900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7293,6 +7553,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7316,6 +7593,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
+dependencies = [
+ "bit-vec 0.5.1",
+ "num-bigint 0.2.6",
+]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "bit-vec 0.6.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.77"
 default-run = "qdrant"
 
 [features]
-default = ["web", "parking_lot"]
+default = ["web", "parking_lot", "rustls-mbedtls"]
 web = ["actix-web"]
 multiling-chinese = ["segment/multiling-chinese"]
 multiling-japanese = ["segment/multiling-japanese"]
@@ -34,6 +34,8 @@ tokio-tracing = ["tokio/tracing"]
 stacktrace = ["rstack-self"]
 chaos-testing = []
 data-consistency-check = ["collection/data-consistency-check"]
+ring = ["rustls/ring"]
+rustls-mbedtls = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider", "rustls-mbedtls-provider-utils", "rustls-native-certs"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"
@@ -78,9 +80,13 @@ tower = { version = "0.4.13" }
 tower-layer = "0.3.2"
 reqwest = { workspace = true }
 # rustls minor version must be synced with actix-web
-rustls = { version = "0.23.11", default-features = false, features = [ "logging", "std", "tls12", "ring"] }
+rustls = { version = "0.23.11", default-features = false, features = [ "logging", "std", "tls12"] }
 rustls-pki-types = "1.7.0"
 rustls-pemfile = "2.1.2"
+rustls-mbedcrypto-provider = { version = "0.1.0" }
+rustls-mbedpki-provider = { version = "0.1.0", optional = true }
+rustls-mbedtls-provider-utils = { version = "0.2.0", optional = true }
+rustls-native-certs = { version = "0.7.0", optional = true }
 prometheus = { version = "0.13.4", default-features = false }
 validator = { workspace = true }
 jsonwebtoken = "9.3.0"
@@ -117,6 +123,9 @@ pyroscope = "0.5.7"
 pyroscope_pprofrs = "0.2.7"
 # Backtrace
 rstack-self = { version = "0.3.0", optional = true }
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+rustls-mbedcrypto-provider = { version = "0.1.0", features = ["rdrand"], optional = true }
 
 [target.'cfg(all(not(target_env = "msvc"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/src/common/http_client.rs
+++ b/src/common/http_client.rs
@@ -1,8 +1,11 @@
+use std::fs::File;
 use std::path::Path;
-use std::{fs, io, result};
+use std::{io, result};
 
 use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderValue};
 use storage::content_manager::errors::StorageError;
+#[cfg(feature = "rustls-mbedtls")]
+use {rustls::crypto::CryptoProvider, std::io::BufReader, std::sync::Arc};
 
 use super::auth::HTTP_HEADER_API_KEY;
 use crate::settings::{Settings, TlsConfig};
@@ -61,19 +64,7 @@ fn https_client(
     tls_config: Option<&TlsConfig>,
     verify_https_client_certificate: bool,
 ) -> Result<reqwest::Client> {
-    let mut builder = reqwest::Client::builder();
-
-    // Configure TLS root certificate and validation
-    if let Some(tls_config) = tls_config {
-        builder = builder.add_root_certificate(https_client_ca_cert(tls_config.ca_cert.as_ref())?);
-
-        if verify_https_client_certificate {
-            builder = builder.identity(https_client_identity(
-                tls_config.cert.as_ref(),
-                tls_config.key.as_ref(),
-            )?);
-        }
-    }
+    let mut builder = create_rustls_client_builder(tls_config, verify_https_client_certificate)?;
 
     // Attach API key as sensitive header
     if let Some(api_key) = api_key {
@@ -89,20 +80,44 @@ fn https_client(
     Ok(client)
 }
 
+#[cfg(not(feature = "rustls-mbedtls"))]
+fn create_rustls_client_builder(
+    tls_config: Option<&TlsConfig>,
+    verify_https_client_certificate: bool,
+) -> Result<reqwest::ClientBuilder> {
+    let mut builder = reqwest::Client::builder();
+
+    // Configure TLS root certificate and validation
+    if let Some(tls_config) = tls_config {
+        builder = builder.add_root_certificate(https_client_ca_cert(tls_config.ca_cert.as_ref())?);
+
+        if verify_https_client_certificate {
+            builder = builder.identity(https_client_identity(
+                tls_config.cert.as_ref(),
+                tls_config.key.as_ref(),
+            )?);
+        }
+    };
+
+    Ok(builder)
+}
+
+#[cfg(not(feature = "rustls-mbedtls"))]
 fn https_client_ca_cert(ca_cert: &Path) -> Result<reqwest::tls::Certificate> {
-    let ca_cert_pem =
-        fs::read(ca_cert).map_err(|err| Error::failed_to_read(err, "CA certificate", ca_cert))?;
+    let ca_cert_pem = std::fs::read(ca_cert)
+        .map_err(|err| Error::failed_to_read(err, "CA certificate", ca_cert))?;
 
     let ca_cert = reqwest::Certificate::from_pem(&ca_cert_pem)?;
 
     Ok(ca_cert)
 }
 
+#[cfg(not(feature = "rustls-mbedtls"))]
 fn https_client_identity(cert: &Path, key: &Path) -> Result<reqwest::tls::Identity> {
     let mut identity_pem =
-        fs::read(cert).map_err(|err| Error::failed_to_read(err, "certificate", cert))?;
+        std::fs::read(cert).map_err(|err| Error::failed_to_read(err, "certificate", cert))?;
 
-    let mut key_file = fs::File::open(key).map_err(|err| Error::failed_to_read(err, "key", key))?;
+    let mut key_file = File::open(key).map_err(|err| Error::failed_to_read(err, "key", key))?;
 
     // Concatenate certificate and key into a single PEM bytes
     io::copy(&mut key_file, &mut identity_pem)
@@ -111,6 +126,87 @@ fn https_client_identity(cert: &Path, key: &Path) -> Result<reqwest::tls::Identi
     let identity = reqwest::Identity::from_pem(&identity_pem)?;
 
     Ok(identity)
+}
+
+#[cfg(feature = "rustls-mbedtls")]
+pub fn get_mbedtls_crypto_provider() -> Arc<CryptoProvider> {
+    static MBEDTLS_CRYPTO_PROVIDER: std::sync::OnceLock<Arc<CryptoProvider>> =
+        std::sync::OnceLock::new();
+    let crypto_provider = MBEDTLS_CRYPTO_PROVIDER
+        .get_or_init(|| Arc::new(rustls_mbedcrypto_provider::mbedtls_crypto_provider()));
+    crypto_provider.clone()
+}
+
+#[cfg(feature = "rustls-mbedtls")]
+fn create_rustls_client_builder(
+    tls_config: Option<&TlsConfig>,
+    verify_https_client_certificate: bool,
+) -> Result<reqwest::ClientBuilder> {
+    let crypto_provider = get_mbedtls_crypto_provider();
+    let rustls_client_cfg = rustls::ClientConfig::builder_with_provider(crypto_provider.clone())
+        .with_safe_default_protocol_versions()
+        .map_err(Error::Rustls)?;
+
+    // Configure TLS root certificate
+    let mut root_certs: Vec<_> = rustls_native_certs::load_native_certs()
+        .map_err(|err| Error::io(err, "could not load platform certs"))?;
+    if let Some(tls_config) = tls_config {
+        let mut certs = https_client_ca_cert(tls_config.ca_cert.as_ref())?;
+        root_certs.append(&mut certs);
+    }
+    let client_cert_verifier = rustls_mbedpki_provider::MbedTlsServerCertVerifier::new(&root_certs)
+        .map_err(rustls_mbedtls_provider_utils::error::mbedtls_err_into_rustls_err)
+        .map_err(Error::Rustls)?;
+    let rustls_client_cfg = rustls_client_cfg
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(client_cert_verifier));
+
+    // Configure TLS client certificate validation
+    let rustls_client_cfg = match (tls_config, verify_https_client_certificate) {
+        (Some(tls_config), true) => {
+            let (certs, key) =
+                https_client_identity(tls_config.cert.as_ref(), tls_config.key.as_ref())?;
+            rustls_client_cfg
+                .with_client_auth_cert(certs, key)
+                .map_err(Error::Rustls)?
+        }
+        _ => rustls_client_cfg.with_no_client_auth(),
+    };
+    Ok(reqwest::Client::builder().use_preconfigured_tls(rustls_client_cfg))
+}
+
+#[cfg(feature = "rustls-mbedtls")]
+fn https_client_ca_cert(ca_cert: &Path) -> Result<Vec<rustls_pki_types::CertificateDer<'static>>> {
+    let file = File::open(ca_cert).map_err(|err| Error::io(err, "CA certificate"))?;
+    let mut reader = BufReader::new(file);
+
+    rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| Error::io(err, "CA certificate"))
+}
+
+#[cfg(feature = "rustls-mbedtls")]
+fn https_client_identity(
+    cert: &Path,
+    key: &Path,
+) -> Result<(
+    Vec<rustls_pki_types::CertificateDer<'static>>,
+    rustls_pki_types::PrivateKeyDer<'static>,
+)> {
+    let cert_file =
+        File::open(cert).map_err(|err| Error::failed_to_read(err, "certificate", cert))?;
+    let mut cert_file_reader = BufReader::new(cert_file);
+    let certs: Vec<rustls_pki_types::CertificateDer> = rustls_pemfile::certs(&mut cert_file_reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| Error::io(err, "CA certificate"))?;
+
+    let key_file = File::open(key).map_err(|err| Error::failed_to_read(err, "key", key))?;
+    let mut key_file_reader = BufReader::new(key_file);
+    let private_key = rustls_pemfile::private_key(&mut key_file_reader)
+        .map_err(|err| Error::failed_to_read(err, "key", key))?
+        .ok_or(Error::NoPrivateKey)?;
+
+    Ok((certs, private_key))
 }
 
 pub type Result<T, E = Error> = result::Result<T, E>;
@@ -125,6 +221,12 @@ pub enum Error {
 
     #[error("failed to setup HTTPS client: {0}")]
     Reqwest(#[from] reqwest::Error),
+
+    #[error("failed to setup HTTPS client: {0}")]
+    Rustls(#[from] rustls::Error),
+
+    #[error("failed to setup HTTPS client: no private key found")]
+    NoPrivateKey,
 
     #[error("malformed API key")]
     MalformedApiKey(#[source] InvalidHeaderValue),


### PR DESCRIPTION
- Add `rustls-mbedtls-provider` crates as dependencies.
- Use `rustls-mbedtls-provider` for qdrant server.
- Use `rustls-mbedtls-provider` for clients in code.
- Add features `ring` and `rustls-mbedtls` to choose different crypto/pki provider for TLS library.