### PR TITLE
Create build_image.sh

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xe
+ECR_URL="${ECR_URL:-local}"
+python3 -m pip install toml --user
+VERSION=$(python3 -c "import toml; import sys; values = toml.loads(sys.stdin.read()); print(values['package']['version'])" < Cargo.toml)
+URL="$ECR_URL/qdrant:v$VERSION-$QDRANT_BRANCH-$BUILD_ID"
+docker build --no-cache -t "$URL" .
+if [ "$ECR_URL" != "local" ];then
+    docker push "$URL"
+fi


### PR DESCRIPTION
This script allows to build and tag a docker image.
If the ECR url is provided, it will push the image to the ECR

If you want to push to ECR, you need to provide the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

